### PR TITLE
Fix (important) typos in the setup instructions :memo:

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ Continue with the rules for existing projects.
     }
   });
   ```
-- [ ] Add dependencies to the `functions/package.json` by running `nmp install --save`:
+- [ ] Add dependencies to the `functions/package.json` by running `npm install --save`:
   ```shell
     $ cd functions
-    $ npm install --save deepcopy@^0.6.6
+    $ npm install --save deepcopy@^0.6.3
     $ npm install --save ejs@^2.5.7
     $ npm install --save firebase-admin@^4.1.1
     $ npm install --save firebase-functions@^0.5.1
@@ -274,7 +274,7 @@ Continue with the rules for existing projects.
 
 - [ ] Copy the `public/` folder into the app
 
-- [ ] Deploy the new functions: `functions deploy`
+- [ ] Deploy the new functions: `firebase deploy`
 - [ ] Follow the instructions in the the command line to initialize and confirm
       the wipeout rules
 

--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ Continue with the rules for existing projects.
    ```
 - [ ] Staying within the functions folder, install the development dependencies similarly:
    ```shell
-   $ npm install --save-dev chai@<=3.5
+   $ npm install --save-dev chai@^3.5
    $ npm install --save-dev chai-as-promised@^6.0.0
-   $ nmp install --save-dev mocha@^3.4.2
+   $ npm install --save-dev mocha@^3.4.2
    $ npm install --save-dev sinon@^2.3.2
    $ npm install --save-dev sinon-stub-promise@^4.0.0
    ```


### PR DESCRIPTION
This PR fixes typos two lines in the list of `npm install`s that currently fail.